### PR TITLE
Prevent conflict with luajit

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = fluent-bit
 	pkgdesc = Collect data/logs from different sources, unify and send them to multiple destinations.
 	pkgver = 2.0.5
-	pkgrel = 1
+	pkgrel = 2
 	url = https://fluentbit.io/
 	arch = x86_64
 	arch = aarch64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@
 pkgname=fluent-bit
 
 pkgver=2.0.5
-pkgrel=1
+pkgrel=2
 epoch=
 
 pkgdesc='Collect data/logs from different sources, unify and send them to multiple destinations.'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -46,6 +46,7 @@ build() {
         -DFLB_OUT_NATS=Yes \
         -DFLB_HTTP_SERVER=Yes \
         -DMBEDTLS_FATAL_WARNINGS=Off \
+        -DLUAJIT_BUILD_EXE=Off \
         ..
     make
 }


### PR DESCRIPTION
Conflict happened on `/usr/bin/luajit`, this branch aims to prevent it
by not building the `luajit` binary at all.