### PR TITLE
Update PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -62,11 +62,6 @@ package() {
     # install binaries and libraries
     make DESTDIR="$pkgdir/" install
 
-    # put systemd unit files in the right spot (make install puts them in /lib/systemd/system)
-    mkdir -p "$pkgdir/usr/lib/systemd/system"
-    mv "$pkgdir/lib/systemd/system/fluent-bit.service" "$pkgdir/usr/lib/systemd/system"
-    rm -rf "$pkgdir/lib"
-
     # install license file and documentation
     cd "$srcdir"
     install -Dm 644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"


### PR DESCRIPTION
I get this error when building lately:
```
-- Installing: /home/vond/fluent-bit/pkg/fluent-bit/usr/lib/fluent-bit/libfluent-bit.so
-- Installing: /home/vond/fluent-bit/pkg/fluent-bit/usr/bin/fluent-bit
-- Installing: /home/vond/fluent-bit/pkg/fluent-bit/usr/lib/systemd/system/fluent-bit.service
-- Installing: /home/vond/fluent-bit/pkg/fluent-bit/etc/fluent-bit/
-- Installing: /home/vond/fluent-bit/pkg/fluent-bit/etc/fluent-bit/fluent-bit.conf
-- Installing: /home/vond/fluent-bit/pkg/fluent-bit/etc/fluent-bit/parsers.conf
-- Installing: /home/vond/fluent-bit/pkg/fluent-bit/etc/fluent-bit/plugins.conf
mv: cannot stat '/home/vond/fluent-bit/pkg/fluent-bit/lib/systemd/system/fluent-bit.service': No such file or directory
==> ERROR: A failure occurred in package().
    Aborting...
```

Note that it seems that `fluent-bit.service` is now correctly installed in `/usr/lib` instead of in `/lib`.

For me, deleting the files to do the copy gets me building again.  Let me know if you're seeing different behavior.